### PR TITLE
Add crc32_combine_nz() and new function triads for crc32c and cksum (currently only cksum crcs without stream length appended to input).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 # Testing files
 /build/
 /Gemfile.lock
+/tmp/
 
 # RPM build files
 /rpmbuild/

--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
 # libcrc32trim
 
-_libcrc32trim_ currently exposes two functions, `crc32_trim_leading()` and
-`crc32_trim_trailing()`. These provide opposite functionality to that of
-_[zlib's](https://github.com/madler/zlib)_ `crc32_combine()`.
+_libcrc32trim_ exposes a number of functions which perform combine and trim operations for several CRC-32 implementations.
 
+`crc32_combine_nz()`, `crc32c_combine()`, and `cksum_combine_no_len()` all perform a combine operation like _[zlib's](https://github.com/madler/zlib)_ `crc32_combine()`.
 ```c
-/*
- * NOTE: crc32_combine() is part of zlib and is included here for
- * demonstrative purposes only.
- */
-crcAB = crc32_combine(crcA, crcB, lenB);
+crcAB = crc32_combine_nz(crcA, crcB, lenB);
+crcAB = crc32c_combine(crcA, crcB, lenB);
+crcAB = cksum_combine_no_len(crcA, crcB, lenB);
 ```
 
+`crc32_trim_leading()`, `crc32c_trim_leading()`, and `cksum_trim_leading_no_len()` all perform a leading trim.
 ```c
 crcB = crc32_trim_leading(crcAB, crcA, lenB);
+crcB = crc32c_trim_leading(crcAB, crcA, lenB);
+crcB = cksum_trim_leading_no_len(crcAB, crcA, lenB);
 ```
 
+`crc32_trim_trailing()`, `crc32c_trim_trailing()`, and `cksum_trim_trailing_no_len()` all perform a trailing trim.
 ```c
 crcA = crc32_trim_trailing(crcAB, crcB, lenB);
+crcA = crc32c_trim_trailing(crcAB, crcB, lenB);
+crcA = cksum_trim_trailing_no_len(crcAB, crcB, lenB);
 ```
 
 The initial motivation for `crc32_trim_trailing()` was to compute the crc32 of
@@ -31,11 +34,11 @@ needing the original stream.
 
 ## Installation
 
-_libcrc32trim_ has build time dependencies on gcc, make, and zlib-devel. It also has a run time dependency on zlib. zlib installation is not explicitly included in the following steps since zlib is a dependency of zlib-devel. However, please take this into account when building and installing on separate hosts. These package names may vary slightly between distros.
+_libcrc32trim_ has build time dependencies on gcc and make. These package names may vary slightly between distros.
 
 Install build time dependencies on CentOS.
 ```
-sudo yum install gcc make zlib-devel
+sudo yum install gcc make
 ```
 
 Build.
@@ -50,7 +53,7 @@ sudo make install
 
 The vagrant environment can also be used to build an rpm.
 
-To spin up the CentOS 7 enviroment and build an rpm use the following. This will clean up the vm.
+To spin up the CentOS 7 environment and build an rpm use the following. This will clean up the vm.
 ```
 ./runner.sh buildrpm
 ```

--- a/crc32trim.h
+++ b/crc32trim.h
@@ -14,15 +14,55 @@
 extern "C" {
 #endif
 
-#ifndef NO_ZLIB
+extern unsigned long crc32_combine_nz(
+    unsigned long crcA,
+    unsigned long crcB,
+    long lenB
+);
+
 extern unsigned long crc32_trim_leading(
     unsigned long crcAB,
     unsigned long crcA,
     long lenB
 );
-#endif
 
 extern unsigned long crc32_trim_trailing(
+    unsigned long crcAB,
+    unsigned long crcB,
+    long lenB
+);
+
+extern unsigned long crc32c_combine(
+    unsigned long crcA,
+    unsigned long crcB,
+    long lenB
+);
+
+extern unsigned long crc32c_trim_leading(
+    unsigned long crcAB,
+    unsigned long crcA,
+    long lenB
+);
+
+extern unsigned long crc32c_trim_trailing(
+    unsigned long crcAB,
+    unsigned long crcB,
+    long lenB
+);
+
+extern unsigned long cksum_combine_no_len(
+    unsigned long crcA,
+    unsigned long crcB,
+    long lenB
+);
+
+extern unsigned long cksum_trim_leading_no_len(
+    unsigned long crcAB,
+    unsigned long crcA,
+    long lenB
+);
+
+extern unsigned long cksum_trim_trailing_no_len(
     unsigned long crcAB,
     unsigned long crcB,
     long lenB

--- a/provisioner.sh
+++ b/provisioner.sh
@@ -5,5 +5,4 @@ set -e
 yum install -y \
   gcc \
   make \
-  rpm-build \
-  zlib-devel
+  rpm-build

--- a/test/test_cksum.c
+++ b/test/test_cksum.c
@@ -1,0 +1,47 @@
+#include "unity.h"
+#include "crc32trim.h"
+
+void test_cksum_combine_no_len(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcA  = 0xd85c7e3fUL; // cksum (no len) for 'this'
+  crcB  = 0x4c536d68UL; // cksum (no len) for 'that'
+  lenB  = 4L;
+
+  crcAB = cksum_combine_no_len(crcA, crcB, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcAB, 0x620d7ac6UL); // cksum (no len) for 'thisthat'
+}
+
+void test_cksum_trim_leading_no_len(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcAB = 0x620d7ac6UL; // cksum (no len) for 'thisthat'
+  crcA  = 0xd85c7e3fUL; // cksum (no len) for 'this'
+  lenB  = 4L;
+
+  crcB = cksum_trim_leading_no_len(crcAB, crcA, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcB, 0x4c536d68UL); // cksum (no len) for 'that'
+}
+
+void test_cksum_trim_trailing_no_len(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcAB = 0x620d7ac6UL; // cksum (no len) for 'thisthat'
+  crcB  = 0x4c536d68UL; // cksum (no len) for 'that'
+  lenB  = 4L;
+
+  crcA = cksum_trim_trailing_no_len(crcAB, crcB, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcA, 0xd85c7e3fUL); // cksum (no len) for 'this'
+}

--- a/test/test_crc32.c
+++ b/test/test_crc32.c
@@ -1,6 +1,20 @@
 #include "unity.h"
 #include "crc32trim.h"
-#include <zlib.h>
+
+void test_crc32_combine_nz(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcA  = 0xfeee8227UL; // crc32 for 'this'
+  crcB  = 0xa8539d8cUL; // crc32 for 'that'
+  lenB  = 4L;
+
+  crcAB = crc32_combine_nz(crcA, crcB, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcAB, 0xedffc49cUL); // crc32 for 'thisthat'
+}
 
 void test_crc32_trim_leading(void) {
   unsigned long crcA;
@@ -14,7 +28,7 @@ void test_crc32_trim_leading(void) {
 
   crcB = crc32_trim_leading(crcAB, crcA, lenB);
 
-  TEST_ASSERT_EQUAL_UINT(crcB,0xa8539d8cUL); // crc32 for 'that'
+  TEST_ASSERT_EQUAL_UINT(crcB, 0xa8539d8cUL); // crc32 for 'that'
 }
 
 void test_crc32_trim_trailing(void) {
@@ -29,5 +43,5 @@ void test_crc32_trim_trailing(void) {
 
   crcA = crc32_trim_trailing(crcAB, crcB, lenB);
 
-  TEST_ASSERT_EQUAL_UINT(crcA,0xfeee8227UL); // crc32 for 'this'
+  TEST_ASSERT_EQUAL_UINT(crcA, 0xfeee8227UL); // crc32 for 'this'
 }

--- a/test/test_crc32c.c
+++ b/test/test_crc32c.c
@@ -1,0 +1,47 @@
+#include "unity.h"
+#include "crc32trim.h"
+
+void test_crc32c_combine(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcA  = 0xd4301c5dUL; // crc32c for 'this'
+  crcB  = 0x9deebb0eUL; // crc32c for 'that'
+  lenB  = 4L;
+
+  crcAB = crc32c_combine(crcA, crcB, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcAB, 0x0d252e1bUL); // crc32c for 'thisthat'
+}
+
+void test_crc32c_trim_leading(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcAB = 0x0d252e1bUL; // crc32c for 'thisthat'
+  crcA  = 0xd4301c5dUL; // crc32c for 'this'
+  lenB  = 4L;
+
+  crcB = crc32c_trim_leading(crcAB, crcA, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcB, 0x9deebb0eUL); // crc32c for 'that'
+}
+
+void test_crc32c_trim_trailing(void) {
+  unsigned long crcA;
+  unsigned long crcAB;
+  unsigned long crcB;
+  long lenB;
+
+  crcAB = 0x0d252e1bUL; // crc32c for 'thisthat'
+  crcB  = 0x9deebb0eUL; // crc32c for 'that'
+  lenB  = 4L;
+
+  crcA = crc32c_trim_trailing(crcAB, crcB, lenB);
+
+  TEST_ASSERT_EQUAL_UINT(crcA, 0xd4301c5dUL); // crc32c for 'this'
+}


### PR DESCRIPTION
I reworked the internal code to support forms ("normal" and "reflected") and operations ("combine" and "trim_trailing"; "trim_leading" is really just a reordered "combine" under the hood). The Cartesian product of these concepts supports both the previously existing and newly added operations exposed in the API.

`crc32_combine_nz()` (a native, "non-zlib", combine implementation) has been added to round out the previously existing trim functions.

This PR also adds function triads supporting two new flavors of crc32; crc32c and cksum (currently only cksum crcs without stream length appended to input).

I plan to add a function triad for cksum crcs with stream length appended to input (as the `cksum` util produces) soon, which will build upon the `cksum_*_no_len()` triad added in this PR.